### PR TITLE
Display Schedule with user tasks

### DIFF
--- a/src/app/generateSchedule.ts
+++ b/src/app/generateSchedule.ts
@@ -1,9 +1,11 @@
+import { TaskTypes } from "./lib/enum/tasktypes";
 export interface Availability {
   startTime: Date; 
   endTime: Date; 
 }
 
 export interface Task {
+  taskType: TaskTypes;
   name: string;
   duration?: number; 
   startTime?: Date;
@@ -11,6 +13,7 @@ export interface Task {
 }
 
 export interface ScheduledTasks {
+  taskType: TaskTypes;
   name: string; 
   startTime: Date;  
   endTime: Date; 
@@ -23,8 +26,8 @@ export function generateSchedule(availability: Availability, tasks: Task[]): Tas
   for (const task of tasks) {
     if (task.startTime && task.endTime) {
       // task fits within availability and doesn't overlap existing tasks
-      if (isTaskValid(task.startTime, task.endTime,availability, scheduledTasks)) {
-        scheduledTasks.push({ name: task.name, startTime: task.startTime, endTime: task.endTime});
+      if (isTaskValid(task.startTime, task.endTime, availability, scheduledTasks)) {
+        scheduledTasks.push({taskType: TaskTypes.scheduled, name: task.name, startTime: task.startTime, endTime: task.endTime});
       } else {
           // later on we can return the unscheduledTasks 
         console.warn(`Task '${task.name}' conflicts with availability or other tasks.`);
@@ -62,7 +65,7 @@ function scheduleTaskWithDuration(task: Task, availability: Availability, schedu
 
     if(isTaskValid(startTime, endTime, availability, scheduledTasks)) 
       {
-        const newScheduledTask = {name: task.name, startTime, endTime}
+        const newScheduledTask = {taskType: TaskTypes.scheduled, name: task.name, startTime, endTime}
         return newScheduledTask; 
     }
    }
@@ -70,13 +73,4 @@ function scheduleTaskWithDuration(task: Task, availability: Availability, schedu
   return null 
 }
 
-
-
-  // TODO: export to lib file
-export function formatTime(date: Date): string {
-  const hours = date.getHours() % 12 || 12;
-  const minutes = date.getMinutes().toString().padStart(2, "0");
-  const indicator = date.getHours() >= 12 ? "PM" : "AM";
-  return `${hours}:${minutes} ${indicator}`;
-  }
 

--- a/src/app/lib/enum/tasktypes.ts
+++ b/src/app/lib/enum/tasktypes.ts
@@ -1,0 +1,4 @@
+export const enum TaskTypes {
+    duration = 'duration',
+    scheduled = 'scheduled'
+}

--- a/src/app/lib/generateSchedule.ts
+++ b/src/app/lib/generateSchedule.ts
@@ -1,7 +1,7 @@
-import { TaskTypes } from "./lib/enum/tasktypes";
+import { TaskTypes } from "./enum/taskTypes";
 export interface Availability {
-  startTime: Date; 
-  endTime: Date; 
+  startTime: Date ; 
+  endTime: Date ; 
 }
 
 export interface Task {

--- a/src/app/lib/placeholder-data.ts
+++ b/src/app/lib/placeholder-data.ts
@@ -1,5 +1,5 @@
 import { Availability, Task, generateSchedule } from "../generateSchedule";
-
+import { TaskTypes } from "./enum/tasktypes";
 export const availabilityOne: Availability = {
   startTime: new Date("2024-07-02T09:00:00"), // Wednesday, July 2nd at 9:00 AM
   endTime: new Date("2024-07-02T17:00:00"), // Wednesday, July 2nd at 5:00 PM
@@ -12,24 +12,30 @@ export const availabilityTwo: Availability = {
 
 export const testTasks: Task[] = [
   {
+    taskType: TaskTypes.scheduled,
     name: "Brainstorming Session",
     startTime: new Date("2024-07-02T15:00:00"), // Wednesday, July 2nd at 3:00 PM
     endTime: new Date("2024-07-02T16:30:00"), //
-  }, {
+  }, 
+  {
+    taskType: TaskTypes.scheduled,
     name: "Meeting with Team A",
     startTime: new Date("2024-07-02T11:00:00"), // Wednesday, July 2nd at 11:00 AM
     endTime: new Date("2024-07-02T12:30:00"),
   },
   {
+    taskType: TaskTypes.scheduled,
     name: "Work out session",
     startTime: new Date("2024-07-02T12:00:00"), 
     endTime: new Date("2024-07-02T13:30:00"),
   },
   {
+    taskType: TaskTypes.duration,
     name: "Client Presentation",
     duration: 60, // 60 minutes
   },
   {
+    taskType: TaskTypes.duration,
     name: "Code Review",
     duration: 30, // 30 minutes
   },

--- a/src/app/lib/placeholder-data.ts
+++ b/src/app/lib/placeholder-data.ts
@@ -1,5 +1,5 @@
-import { Availability, Task, generateSchedule } from "../generateSchedule";
-import { TaskTypes } from "./enum/tasktypes";
+import { Availability, Task } from "./generateSchedule";
+import { TaskTypes } from "./enum/taskTypes";
 export const availabilityOne: Availability = {
   startTime: new Date("2024-07-02T09:00:00"), // Wednesday, July 2nd at 9:00 AM
   endTime: new Date("2024-07-02T17:00:00"), // Wednesday, July 2nd at 5:00 PM
@@ -40,7 +40,3 @@ export const testTasks: Task[] = [
     duration: 30, // 30 minutes
   },
 ];
-
-// console.log(generateSchedule(availabilityOne, testTasks))
-// console.log("2nd Test")
-// console.log(generateSchedule(availabilityTwo, testTasks))

--- a/src/app/lib/tasks.ts
+++ b/src/app/lib/tasks.ts
@@ -1,6 +1,7 @@
-export const unscheduledTasks = [];
+import { Task, Availability, ScheduledTasks } from "./generateSchedule";
+export const unscheduledTasks: (Task|ScheduledTasks)[] = [];
 
-export const availabilityTime = {
+export const availabilityTime : Availability = {
     startTime: null,
     endTime: null
 }

--- a/src/app/lib/tasks.ts
+++ b/src/app/lib/tasks.ts
@@ -1,0 +1,6 @@
+export const unscheduledTasks = [];
+
+export const availabilityTime = {
+    startTime: null,
+    endTime: null
+}

--- a/src/app/lib/time-conversion.ts
+++ b/src/app/lib/time-conversion.ts
@@ -1,0 +1,30 @@
+export const convertMinutesDurationToMillisecondsDuration = (minutesDuration) => {
+    return minutesDuration * 60 * 1000
+}
+
+export const convertStringtoDateTime = (timeString, day) => {
+    const addDays = (date, days) => {
+        const newDate = new Date(date)
+        newDate.setDate(date.getDate() + days)
+        return newDate
+    }
+    const [time, indicator] = timeString.split(" ")
+    let [h, m] = time.split(":")
+    if (indicator == "pm") {
+        h = parseInt(h) + 12
+    }
+    const currentDate = new Date()
+    currentDate.setHours(h,m)
+    if(day.tomorrow) {
+        const tomorrowsDate = addDays(currentDate, 1)
+        return tomorrowsDate
+    }
+    else return currentDate
+}
+
+  export function formatTime(date: Date): string {
+    const hours = date.getHours() % 12 || 12;
+    const minutes = date.getMinutes().toString().padStart(2, "0");
+    const indicator = date.getHours() >= 12 ? "PM" : "AM";
+    return `${hours}:${minutes} ${indicator}`;
+    }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import React from "react";
-import Link from "next/link";
 import Form from "../components/Form/Form";
 
 export default function Home() {
@@ -7,7 +6,6 @@ export default function Home() {
       <div className="flex flex-col items-center justify-between p-24">
         <p>PAUSE TO START</p>
         <Form/>
-        <Link href="/schedule">View Schedule</Link>
       </div>
   );
 }

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -2,7 +2,7 @@
 
 import React, { useState, useEffect } from "react";
 import { formatTime } from "../lib/time-conversion";
-import { generateSchedule } from "../generateSchedule";
+import { generateSchedule } from "../lib/generateSchedule";
 import { availabilityTime, unscheduledTasks } from "../lib/tasks";
 import { useRouter } from "next/navigation";
 

--- a/src/app/schedule/page.tsx
+++ b/src/app/schedule/page.tsx
@@ -1,15 +1,25 @@
 "use client";
 
-import React, { useState } from "react";
-import { Task, formatTime } from "../generateSchedule";
+import React, { useState, useEffect } from "react";
+import { formatTime } from "../lib/time-conversion";
 import { generateSchedule } from "../generateSchedule";
-import { availabilityOne, testTasks } from "../lib/placeholder-data";
+import { availabilityTime, unscheduledTasks } from "../lib/tasks";
+import { useRouter } from "next/navigation";
+
 
 export default function DisplaySchedule() {
+  const router = useRouter()
   const [schedule, setSchedule] = useState([]);
 
+  useEffect(() => {
+    setSchedule(generateSchedule(availabilityTime, unscheduledTasks));
+  }, [])
+
   const handleClick = () => {
-    setSchedule(generateSchedule(availabilityOne, testTasks));
+    availabilityTime.startTime = null;
+    availabilityTime.endTime = null;
+    unscheduledTasks.length = 0
+    router.push('/')
   };
 
   return (
@@ -28,7 +38,7 @@ export default function DisplaySchedule() {
         className="bg-transparent hover:bg-blue-500 text-blue-700 font-semibold hover:text-white py-2 px-4 border border-blue-500 hover:border-transparent rounded"
         onClick={handleClick}
       >
-        Submit
+        create new schedule
       </button>
       
     </div>

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -2,14 +2,11 @@
 import { useState } from "react";
 import React from 'react'
 import { useRouter } from "next/navigation";
-import { Task, Availability, ScheduledTasks, generateSchedule } from "../../app/generateSchedule";
+import { Task, ScheduledTasks } from "../../app/lib/generateSchedule";
 import { convertStringtoDateTime } from "../../app/lib/time-conversion";
 import { formatTime } from "../../app/lib/time-conversion";
-import { TaskTypes } from "../../app/lib/enum/tasktypes";
-import Link from "next/link";
+import { TaskTypes } from "../../app/lib/enum/taskTypes";
 import { unscheduledTasks, availabilityTime } from "../../app/lib/tasks";
-// TODO: availability time left 
-// TODO: enforce user to input proper date time format
 
 const Form = () => {
     const router = useRouter()
@@ -33,7 +30,7 @@ const Form = () => {
         startTime: "",
         endTime: "",
     })
-    const [taskList, setTaskList] = useState([])
+    const [taskList, setTaskList] = useState<(Task|ScheduledTasks)[]>([])
     const [activeTaskTab, setActiveTaskTab] = useState<TaskTypes>(TaskTypes.duration)
 
     const handleAvailabilityChange = (e) =>

--- a/src/components/Form/Form.tsx
+++ b/src/components/Form/Form.tsx
@@ -1,38 +1,44 @@
 'use client'
 import { useState } from "react";
 import React from 'react'
-import { Task, Availability, ScheduledTasks } from "../../app/generateSchedule";
+import { useRouter } from "next/navigation";
+import { Task, Availability, ScheduledTasks, generateSchedule } from "../../app/generateSchedule";
+import { convertStringtoDateTime } from "../../app/lib/time-conversion";
+import { formatTime } from "../../app/lib/time-conversion";
+import { TaskTypes } from "../../app/lib/enum/tasktypes";
+import Link from "next/link";
+import { unscheduledTasks, availabilityTime } from "../../app/lib/tasks";
+// TODO: availability time left 
+// TODO: enforce user to input proper date time format
 
 const Form = () => {
-    // TODO: constraints for today, current time vs past time
-    // TODO: availability time left 
-    // TODO: set placeholders for input
-    // TODO: reset input once task is submitted OR user switches to another task type
-
-    const enum taskTypes {
-        duration = 'duration', scheduled = 'scheduled'
+    const router = useRouter()
+    const enum TimeShown {
+        current,
+        tomorrow
     }
-    const [availability, setAvailability] = useState({
+
+    const [availabilityForm, setAvailabilityForm] = useState({
         startTime: "9:00 am",
         endTime: "10:00 pm"
     })
-    const [durationTask, setDurationTask] = useState({
-        type: taskTypes.duration,
+    const [durationTaskForm, setDurationTaskForm] = useState({
+        type: TaskTypes.duration,
         name: "",
-        duration: "0"
+        duration: ""
     })
-    const [scheduledTask, setScheduledTask] = useState({
-        type: taskTypes.scheduled,
+    const [scheduledTaskForm, setScheduledTaskForm] = useState({
+        type: TaskTypes.scheduled,
         name: "",
         startTime: "",
         endTime: "",
     })
     const [taskList, setTaskList] = useState([])
-    const [activeTaskTab, setActiveTaskTab] = useState<taskTypes>(taskTypes.duration)
+    const [activeTaskTab, setActiveTaskTab] = useState<TaskTypes>(TaskTypes.duration)
 
     const handleAvailabilityChange = (e) =>
         {
-            setAvailability((prevState) => ({...prevState, [e.target.name]: e.target.value}))
+            setAvailabilityForm((prevState) => ({...prevState, [e.target.name]: e.target.value}))
         }
 
     const renderAvailability = () => {
@@ -40,65 +46,81 @@ const Form = () => {
             <>
             <div>Availability</div>
             <label>start time </label>
-            <input className="border-2" type="text" name="startTime" value={availability.startTime} onChange={handleAvailabilityChange}/>
+            <input className="border-2" type="text" name="startTime" placeholder="9:00 am" value={availabilityForm.startTime} onChange={handleAvailabilityChange}/>
             <label>end time </label>
-            <input className="border-2" type="text" name="endTime" value={availability.endTime} onChange={handleAvailabilityChange}/>
+            <input className="border-2" type="text" name="endTime" placeholder="10:00 pm"value={availabilityForm.endTime} onChange={handleAvailabilityChange}/>
             </>
         )
 
     }
 
+    const addTaskToList = (taskType) => {
+        let task = {}
+
+        switch(taskType) {
+            case TaskTypes.duration:
+                task = {
+                    type: durationTaskForm.type,
+                    name: durationTaskForm.name,
+                    duration: parseInt(durationTaskForm.duration)
+                }
+                setTaskList((prevList) => prevList.concat(task))
+                setDurationTaskForm({...durationTaskForm, name:"", duration:""})
+                break;
+            case TaskTypes.scheduled: 
+                task = {
+                    type: scheduledTaskForm.type,
+                    name: scheduledTaskForm.name,
+                    startTime: convertStringtoDateTime(scheduledTaskForm.startTime, TimeShown.tomorrow),
+                    endTime: convertStringtoDateTime(scheduledTaskForm.endTime, TimeShown.tomorrow)
+                }
+                setTaskList((prevList) => prevList.concat(task))
+                setScheduledTaskForm({...scheduledTaskForm, name: "", startTime: "", endTime: ""})
+                break;
+        }
+    }
+
     const handleDurationTaskChange = (e) => {
-        setDurationTask((prevState) => ({...prevState, [e.target.name]: e.target.value}))
+        setDurationTaskForm((prevState) => ({...prevState, [e.target.name]: e.target.value}))
     }
 
     const renderDurationTask = () => {
         return (
             <div>
             <label>task name </label>
-            <input className="border-2" type="text" name="name" value={durationTask.name} onChange={handleDurationTaskChange}/>
+            <input className="border-2" type="text" name="name" placeholder="workout" value={durationTaskForm.name} onChange={handleDurationTaskChange}/>
             <label>Duration in minutes</label>
-            <input className="border-2" type="text" name="duration" value={durationTask.duration} onChange={handleDurationTaskChange}></input>
+            <input className="border-2" type="text" name="duration" placeholder="60" value={durationTaskForm.duration} onChange={handleDurationTaskChange}></input>
             <button className="bg-slate-500 text-white rounded" onClick={(e) => {e.preventDefault()
-                const task  = {
-                    type: durationTask.type,
-                    name: durationTask.name,
-                    duration: durationTask.duration
-                }
-                setTaskList((prevList) => prevList.concat(task))
+                addTaskToList(TaskTypes.duration)
             }}>add duration task</button>
             </div>
         )
     }
 
     const handleScheduledTaskChange = (e) => {
-        setScheduledTask((prevState) => ({...prevState, [e.target.name]: e.target.value}))
+        setScheduledTaskForm((prevState) => ({...prevState, [e.target.name]: e.target.value}))
     }
 
     const renderScheduledTask = () => {
         return(
             <div>
             <label>Task name </label>
-            <input className="border-2" type="text" name="name" value={scheduledTask.name} onChange={handleScheduledTaskChange}/>
+            <input className="border-2" type="text" name="name" placeholder="workout" value={scheduledTaskForm.name} onChange={handleScheduledTaskChange}/>
             <label>Start Time</label>
-            <input className="border-2" type="text" name="startTime" value={scheduledTask.startTime} onChange={handleScheduledTaskChange}></input>
+            <input className="border-2" type="text" name="startTime" placeholder="3:00 pm" value={scheduledTaskForm.startTime} onChange={handleScheduledTaskChange}></input>
             <label>End Time</label>
-            <input className="border-2" type="text" name="endTime" value={scheduledTask.endTime} onChange={handleScheduledTaskChange}></input>
-            <button className="bg-slate-500 text-white rounded" onClick={(e) => {e.preventDefault()
-                const task = {
-                    type: scheduledTask.type,
-                    name: scheduledTask.name,
-                    startTime: scheduledTask.startTime,
-                    endTime: scheduledTask.endTime
-                }
-                setTaskList((prevList) => prevList.concat(task))
+            <input className="border-2" type="text" name="endTime" placeholder="3:30 pm" value={scheduledTaskForm.endTime} onChange={handleScheduledTaskChange}></input>
+            <button className="bg-slate-500 text-white rounded" onClick={(e) => {
+                e.preventDefault()
+                addTaskToList(TaskTypes.scheduled)
             }}>add scheduled task</button>
             </div>
         )
     }
 
     const renderCreateTask = () => {
-        const tabs = [taskTypes.duration, taskTypes.scheduled]
+        const tabs = [TaskTypes.duration, TaskTypes.scheduled]
 
         return (
         <>
@@ -113,7 +135,7 @@ const Form = () => {
                 )
             })}
         </div>
-        {activeTaskTab === taskTypes.duration ? renderDurationTask() :renderScheduledTask()}
+        {activeTaskTab === TaskTypes.duration ? renderDurationTask() :renderScheduledTask()}
         </>
         )
 
@@ -134,9 +156,9 @@ const Form = () => {
                         <div key={`task-list-item-${index}`}>
                             <span>{`Type: ${task.type} - `}</span>
                             <span>{`Name: ${task.name} - `}</span>
-                            {task.type === taskTypes.duration ? 
+                            {task.type === TaskTypes.duration ? 
                                 <span>{`duration: ${task.duration}`}</span>
-                                : <><span>{`start time: ${task.startTime}`}</span> <span>{`end time: ${task.endTime}`}</span></>
+                                : <><span>{`start time: ${formatTime(task.startTime)}`}</span> <span>{`end time: ${formatTime(task.endTime)}`}</span></>
                             }
                         </div>
                     )
@@ -154,12 +176,10 @@ const Form = () => {
     }
 
     const handleSubmitTasks = () => {
-        // TODO:
-        /*
-        resets form
-        converts string formats to date formats
-        displays schedule
-        */
+        availabilityTime.startTime = convertStringtoDateTime(availabilityForm.startTime, TimeShown.tomorrow)
+        availabilityTime.endTime = convertStringtoDateTime(availabilityForm.endTime, TimeShown.tomorrow) 
+        unscheduledTasks.push(...taskList)
+        router.push('/schedule')
     }
 
     return (
@@ -169,7 +189,12 @@ const Form = () => {
             {renderAvailability()}
             {renderCreateTask()}
             {renderTaskList()}
-            <button className="bg-slate-500 text-white rounded">submit tasks</button>
+            <button className="bg-slate-500 text-white rounded" 
+                onClick={(e) => {
+                    e.preventDefault()
+                    handleSubmitTasks()
+                }}>submit tasks and view schedule
+            </button>
         </form>
         </>
     )


### PR DESCRIPTION
Sends users tasks and availability in expected format to schedule page and displays generated schedule

Changes
- updated unscheduled taskList and availability format to match expected format for generatedSchedule
- automatically display generatedSchedule once routed to schedule page
- updated "submit" button to return to home page so that user can re-create schedule while also resetting availability time and unscheduled tasks list
- moved timeConversion functions to separate file
- started moving enums to their own files



https://github.com/user-attachments/assets/dfe6cc7c-9049-4ab3-9be7-5c5fef9cd4a4

